### PR TITLE
Add an option to force trainer pokemons to be fully evolved after a given level

### DIFF
--- a/worlds/pokemon_emerald/__init__.py
+++ b/worlds/pokemon_emerald/__init__.py
@@ -839,6 +839,7 @@ class PokemonEmeraldWorld(World):
                 RandomizeTrainerParties.option_match_base_stats_and_type
             }
             allow_legendaries = self.options.allow_trainer_legendaries == Toggle.option_true
+            force_fully_evolved_at = self.options.force_fully_evolved.value
 
             per_species_tmhm_moves: Dict[int, List[int]] = {}
 
@@ -848,13 +849,15 @@ class PokemonEmeraldWorld(World):
                     original_species = emerald_data.species[pokemon.species_id]
                     target_bst = sum(original_species.base_stats) if should_match_bst else None
                     target_type = self.random.choice(original_species.types) if should_match_type else None
+                    force_fully_evolved = force_fully_evolved_at != 0 and pokemon.level >= force_fully_evolved_at
 
                     new_species = get_random_species(
                         self.random,
                         self.modified_species,
                         target_bst,
                         target_type,
-                        LEGENDARY_POKEMON if allow_legendaries else set()
+                        LEGENDARY_POKEMON if allow_legendaries else set(),
+                        force_fully_evolved
                     )
 
                     if new_species.species_id not in per_species_tmhm_moves:

--- a/worlds/pokemon_emerald/options.py
+++ b/worlds/pokemon_emerald/options.py
@@ -347,6 +347,16 @@ class AllowTrainerLegendaries(DefaultOnToggle):
     display_name = "Allow Trainer Legendaries"
 
 
+class ForceFullyEvolved(Range):
+    """
+    Level at which trainer pokemons would be forced to be fully evolved. Has no effect unless trainer parties are randomized. Set to 0 to disable.
+    """
+    display_name = "Force fully evolved"
+    range_start = 0
+    range_end = 40
+    default = 0
+
+
 class RandomizeStaticEncounters(Choice):
     """
     Randomizes static encounters (Rayquaza, hidden Kekleons, fake Voltorb pokeballs, etc...)
@@ -774,6 +784,7 @@ class PokemonEmeraldOptions(PerGameCommonOptions):
     match_trainer_levels: MatchTrainerLevels
     match_trainer_levels_bonus: MatchTrainerLevelsBonus
     double_battle_chance: DoubleBattleChance
+    force_fully_evolved: ForceFullyEvolved
     better_shops: BetterShops
 
     remove_roadblocks: RemoveRoadblocks

--- a/worlds/pokemon_emerald/pokemon.py
+++ b/worlds/pokemon_emerald/pokemon.py
@@ -106,7 +106,8 @@ def get_random_species(
         candidates: List[Optional[SpeciesData]],
         nearby_bst: Optional[int] = None,
         species_type: Optional[int] = None,
-        blacklist: Set[int] = set()) -> SpeciesData:
+        blacklist: Set[int] = set(),
+        force_fully_evolved: bool = False) -> SpeciesData:
     filtered_candidates: List[SpeciesData] = [
         species
         for species in candidates
@@ -131,6 +132,9 @@ def get_random_species(
             ]
 
         filtered_candidates = bst_filtered_candidates
+
+    if force_fully_evolved is not None and nearby_bst is None:
+        filtered_candidates = [species for species in filtered_candidates if len(species.evolutions) == 0]
 
     if len(filtered_candidates) == 0:
         return get_random_species(random, candidates, nearby_bst, species_type, LEGENDARY_POKEMON)


### PR DESCRIPTION
This was tested during an archipelago with 4 emerald players with this option on.

This was tested with a patch on your emerald-stable branch though, so hopefully I didn't forget anything when migrating it to target the dev branch.